### PR TITLE
composer update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.336.11",
+            "version": "3.336.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "442039c766a82f06ecfecb0ac2c610d6aaba228d"
+                "reference": "a173ab3af8d9186d266e4937d8254597f36a9e15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/442039c766a82f06ecfecb0ac2c610d6aaba228d",
-                "reference": "442039c766a82f06ecfecb0ac2c610d6aaba228d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a173ab3af8d9186d266e4937d8254597f36a9e15",
+                "reference": "a173ab3af8d9186d266e4937d8254597f36a9e15",
                 "shasum": ""
             },
             "require": {
@@ -154,9 +154,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.336.11"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.336.12"
             },
-            "time": "2025-01-08T19:06:59+00:00"
+            "time": "2025-01-09T19:04:34+00:00"
         },
         {
             "name": "brick/math",
@@ -3998,16 +3998,16 @@
         },
         {
             "name": "revolution/atproto-lexicon-contracts",
-            "version": "1.0.40",
+            "version": "1.0.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/atproto-lexicon-contracts.git",
-                "reference": "adf79a37316cbb986a40c49df0f3a347e0d78c75"
+                "reference": "43a6cb804ffa9a9e52c6bdb10afd680cf26c8144"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/adf79a37316cbb986a40c49df0f3a347e0d78c75",
-                "reference": "adf79a37316cbb986a40c49df0f3a347e0d78c75",
+                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/43a6cb804ffa9a9e52c6bdb10afd680cf26c8144",
+                "reference": "43a6cb804ffa9a9e52c6bdb10afd680cf26c8144",
                 "shasum": ""
             },
             "require": {
@@ -4041,22 +4041,22 @@
                 "contracts"
             ],
             "support": {
-                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.40"
+                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.41"
             },
-            "time": "2024-12-28T03:37:37+00:00"
+            "time": "2025-01-03T04:05:28+00:00"
         },
         {
             "name": "revolution/laravel-bluesky",
-            "version": "0.16.3",
+            "version": "0.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/laravel-bluesky.git",
-                "reference": "90e7d14c81a74b041fe6ab9cc2cc60ce48295b0e"
+                "reference": "97fabb22c065a76a28b4cfc4381e750f27f91a6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/90e7d14c81a74b041fe6ab9cc2cc60ce48295b0e",
-                "reference": "90e7d14c81a74b041fe6ab9cc2cc60ce48295b0e",
+                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/97fabb22c065a76a28b4cfc4381e750f27f91a6d",
+                "reference": "97fabb22c065a76a28b4cfc4381e750f27f91a6d",
                 "shasum": ""
             },
             "require": {
@@ -4067,7 +4067,7 @@
                 "laravel/socialite": "^5.16",
                 "php": "^8.2",
                 "phpseclib/phpseclib": "^3.0",
-                "revolution/atproto-lexicon-contracts": "1.0.40",
+                "revolution/atproto-lexicon-contracts": "1.0.41",
                 "yocto/yoclib-multibase": "^1.2"
             },
             "require-dev": {
@@ -4118,9 +4118,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kawax/laravel-bluesky/issues",
-                "source": "https://github.com/kawax/laravel-bluesky/tree/0.16.3"
+                "source": "https://github.com/kawax/laravel-bluesky/tree/0.16.4"
             },
-            "time": "2025-01-05T05:32:05+00:00"
+            "time": "2025-01-09T09:22:40+00:00"
         },
         {
             "name": "symfony/clock",


### PR DESCRIPTION
- Upgrading aws/aws-sdk-php (3.336.11 => 3.336.12)
- Upgrading revolution/atproto-lexicon-contracts (1.0.40 => 1.0.41)
- Upgrading revolution/laravel-bluesky (0.16.3 => 0.16.4)